### PR TITLE
Non static routing table.

### DIFF
--- a/Nancy.AttributeRouting/AttributeRoutingRegistration.cs
+++ b/Nancy.AttributeRouting/AttributeRoutingRegistration.cs
@@ -24,7 +24,8 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="AttributeRoutingRegistration"/> class.
         /// </summary>
-        public AttributeRoutingRegistration()
+        /// <param name="typeProvider">The routing type provider.</param>
+        public AttributeRoutingRegistration(ITypeProvider typeProvider)
         {
             lock (initializeLock)
             {
@@ -32,9 +33,7 @@
                 {
                     initialized = true;
 
-                    IEnumerable<Type> allTypes =
-                        AppDomain.CurrentDomain.GetAssemblies()
-                            .SelectMany(assembly => assembly.SafeGetTypes());
+                    IEnumerable<Type> allTypes = typeProvider.Types;
 
                     IEnumerable<MethodBase> methods =
                         allTypes.Where(DoesSupportType).SelectMany(GetMethodsWithRouteAttribute);

--- a/Nancy.AttributeRouting/AttributeRoutingRegistration.cs
+++ b/Nancy.AttributeRouting/AttributeRoutingRegistration.cs
@@ -3,9 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Reflection;
-    using Nancy.Bootstrapper;
-    using Nancy.TinyIoc;
+    using Bootstrapper;
 
     /// <inheritdoc/>
     public class AttributeRoutingRegistration : IRegistrations
@@ -15,11 +13,11 @@
             new TypeRegistration(typeof(IUrlBuilder), typeof(UrlBuilder))
         };
 
-        private static bool initialized;
+        private readonly AttributeRoutingTable attributeRoutingTable;
 
-        private static object initializeLock = new object();
+        private readonly IEnumerable<TypeRegistration> interfaceRegistrations;
 
-        private static IEnumerable<TypeRegistration> interfaceRegistrations;
+        private readonly IEnumerable<Type> types;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AttributeRoutingRegistration"/> class.
@@ -27,66 +25,40 @@
         /// <param name="typeProvider">The routing type provider.</param>
         public AttributeRoutingRegistration(ITypeProvider typeProvider)
         {
-            lock (initializeLock)
-            {
-                if (!initialized)
-                {
-                    initialized = true;
+            this.types = typeProvider.Types;
+            this.attributeRoutingTable = new AttributeRoutingTable(typeProvider);
 
-                    IEnumerable<Type> allTypes = typeProvider.Types;
-
-                    IEnumerable<MethodBase> methods =
-                        allTypes.Where(DoesSupportType).SelectMany(GetMethodsWithRouteAttribute);
-
-                    foreach (MethodBase method in methods)
-                    {
-                        AttributeRoutingResolver.Routings.Register(method);
-                    }
-
-                    // Prepare the interface to implementation registration mapping for IoC
-                    interfaceRegistrations =
-                        allTypes.Where(IsInterfaceHavingMethodsWithRouteAttribute)
-                            .Select(@interface => GetTypeRegistration(allTypes, @interface))
-                            .Where(typeRegistration => typeRegistration != null);
-                }
-            }
+            this.interfaceRegistrations = this.types
+                .Where(IsRoutingInterface)
+                .Select(this.ToInterfaceClassPair)
+                .Where(x => x.Item2 != null)
+                .Select(this.ToTypeRegistration);
         }
 
         /// <inheritdoc/>
-        public IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations => null;
+        public IEnumerable<CollectionTypeRegistration> CollectionTypeRegistrations =>
+            null;
 
         /// <inheritdoc/>
-        public IEnumerable<InstanceRegistration> InstanceRegistrations => null;
+        public IEnumerable<InstanceRegistration> InstanceRegistrations =>
+            new[]
+            {
+                new InstanceRegistration(typeof(AttributeRoutingTable), this.attributeRoutingTable)
+            };
 
         /// <inheritdoc/>
-        public IEnumerable<TypeRegistration> TypeRegistrations => typeRegistrations.Concat(interfaceRegistrations);
+        public IEnumerable<TypeRegistration> TypeRegistrations =>
+            typeRegistrations.Concat(this.interfaceRegistrations);
 
-        private static IEnumerable<MethodBase> GetMethodsWithRouteAttribute(Type type) =>
-            type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                .Where(HasRouteAttribute);
+        private static bool IsRoutingInterface(Type type) =>
+            type.IsInterface && RouteAttribute.GetMethods(type).Any();
 
-        private static bool HasRouteAttribute(MethodBase method) =>
-            method.GetCustomAttributes<RouteAttribute>().Any();
+        private Tuple<Type, Type> ToInterfaceClassPair(Type @interface) =>
+            Tuple.Create(
+                @interface,
+                this.types.FirstOrDefault(type => type.GetInterface(@interface.FullName) != null));
 
-        private static bool DoesSupportType(Type type) =>
-            type.IsInterface || (!type.IsAbstract && (type.IsPublic || type.IsNestedPublic));
-
-        private static bool IsInterfaceHavingMethodsWithRouteAttribute(Type type) =>
-            type.IsInterface && GetMethodsWithRouteAttribute(type).Any();
-
-        private static TypeRegistration GetTypeRegistration(IEnumerable<Type> allTypes, Type @interface)
-        {
-            Type implementation =
-                allTypes.FirstOrDefault(type => type.GetInterface(@interface.FullName) != null);
-
-            if (implementation != null)
-            {
-                return new TypeRegistration(@interface, implementation, Lifetime.PerRequest);
-            }
-            else
-            {
-                return null;
-            }
-        }
+        private TypeRegistration ToTypeRegistration(Tuple<Type, Type> interfaceClassPair) =>
+            new TypeRegistration(interfaceClassPair.Item1, interfaceClassPair.Item2, Lifetime.PerRequest);
     }
 }

--- a/Nancy.AttributeRouting/AttributeRoutingResolver.cs
+++ b/Nancy.AttributeRouting/AttributeRoutingResolver.cs
@@ -11,42 +11,29 @@
     /// </summary>
     public class AttributeRoutingResolver : NancyModule
     {
-        static AttributeRoutingResolver()
-        {
-            Routings = new Dictionary<HttpMethod, Dictionary<string, MethodBase>>
-            {
-                { HttpMethod.Delete, new Dictionary<string, MethodBase>() },
-                { HttpMethod.Get, new Dictionary<string, MethodBase>() },
-                { HttpMethod.Options, new Dictionary<string, MethodBase>() },
-                { HttpMethod.Patch, new Dictionary<string, MethodBase>() },
-                { HttpMethod.Post, new Dictionary<string, MethodBase>() },
-                { HttpMethod.Put, new Dictionary<string, MethodBase>() },
-            };
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AttributeRoutingResolver"/> class.
         /// </summary>
         /// <param name="container">The Nancy IoC container.</param>
         public AttributeRoutingResolver(TinyIoCContainer container)
         {
-            Resolve(container, this, this.Delete, HttpMethod.Delete);
-            Resolve(container, this, this.Get, HttpMethod.Get);
-            Resolve(container, this, this.Options, HttpMethod.Options);
-            Resolve(container, this, this.Patch, HttpMethod.Patch);
-            Resolve(container, this, this.Post, HttpMethod.Post);
-            Resolve(container, this, this.Put, HttpMethod.Put);
+            var table = container.Resolve<AttributeRoutingTable>();
+            Resolve(container, this, table.Routings, this.Delete, HttpMethod.Delete);
+            Resolve(container, this, table.Routings, this.Get, HttpMethod.Get);
+            Resolve(container, this, table.Routings, this.Options, HttpMethod.Options);
+            Resolve(container, this, table.Routings, this.Patch, HttpMethod.Patch);
+            Resolve(container, this, table.Routings, this.Post, HttpMethod.Post);
+            Resolve(container, this, table.Routings, this.Put, HttpMethod.Put);
         }
-
-        internal static Dictionary<HttpMethod, Dictionary<string, MethodBase>> Routings { get; }
 
         private static void Resolve(
             TinyIoCContainer container,
             INancyModule module,
+            Dictionary<HttpMethod, Dictionary<string, MethodBase>> routings,
             RouteBuilder builder,
             HttpMethod httpMethod)
         {
-            foreach (KeyValuePair<string, MethodBase> routing in Routings[httpMethod])
+            foreach (KeyValuePair<string, MethodBase> routing in routings[httpMethod])
             {
                 string path = routing.Key;
                 string name = string.Format("{0} {1}", httpMethod, path);

--- a/Nancy.AttributeRouting/AttributeRoutingTable.cs
+++ b/Nancy.AttributeRouting/AttributeRoutingTable.cs
@@ -1,0 +1,36 @@
+﻿namespace Nancy.AttributeRouting
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    internal class AttributeRoutingTable
+    {
+        internal AttributeRoutingTable(ITypeProvider typeProvider)
+        {
+            this.Routings = new Dictionary<HttpMethod, Dictionary<string, MethodBase>>
+            {
+                { HttpMethod.Delete, new Dictionary<string, MethodBase>() },
+                { HttpMethod.Get, new Dictionary<string, MethodBase>() },
+                { HttpMethod.Options, new Dictionary<string, MethodBase>() },
+                { HttpMethod.Patch, new Dictionary<string, MethodBase>() },
+                { HttpMethod.Post, new Dictionary<string, MethodBase>() },
+                { HttpMethod.Put, new Dictionary<string, MethodBase>() },
+            };
+
+            IEnumerable<MethodBase> methods = typeProvider.Types
+                .Where(IsSupported).SelectMany(RouteAttribute.GetMethods);
+
+            foreach (MethodBase method in methods)
+            {
+                this.Routings.Register(method);
+            }
+        }
+
+        internal Dictionary<HttpMethod, Dictionary<string, MethodBase>> Routings { get; }
+
+        private static bool IsSupported(Type type) =>
+            type.IsInterface || (!type.IsAbstract && (type.IsPublic || type.IsNestedPublic));
+    }
+}

--- a/Nancy.AttributeRouting/DefaultTypeProvider.cs
+++ b/Nancy.AttributeRouting/DefaultTypeProvider.cs
@@ -1,0 +1,32 @@
+﻿namespace Nancy.AttributeRouting
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using TinyIoc;
+
+    /// <summary>
+    /// Type provider to provide types for routing register.
+    /// </summary>
+    public interface ITypeProvider
+    {
+        /// <summary>
+        /// Gets the type list for routing register.
+        /// Their methods decorated with <see cref="RouteAttribute"/> will be registed to routing table.
+        /// By default, all types will be registed.
+        /// </summary>
+        /// <value>The type list.</value>
+        IEnumerable<Type> Types { get; }
+    }
+
+    /// <summary>
+    /// The default type provider for routing register.
+    /// </summary>
+    public class DefaultTypeProvider : ITypeProvider
+    {
+        /// <inheritdoc/>
+        public IEnumerable<Type> Types =>
+            AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(assembly => assembly.SafeGetTypes());
+    }
+}

--- a/Nancy.AttributeRouting/Nancy.AttributeRouting.csproj
+++ b/Nancy.AttributeRouting/Nancy.AttributeRouting.csproj
@@ -73,6 +73,7 @@
     <Compile Include="AttributeRoutingRegistration.cs" />
     <Compile Include="AttributeRoutingResolver.cs" />
     <Compile Include="BeforeAttribute.cs" />
+    <Compile Include="DefaultTypeProvider.cs" />
     <Compile Include="Exceptions\DuplicatedRoutingPathsException.cs" />
     <Compile Include="Exceptions\MultipleBeforeAttributeException.cs" />
     <Compile Include="Exceptions\MultipleRouteAttributesException.cs" />

--- a/Nancy.AttributeRouting/Nancy.AttributeRouting.csproj
+++ b/Nancy.AttributeRouting/Nancy.AttributeRouting.csproj
@@ -72,6 +72,7 @@
   <ItemGroup>
     <Compile Include="AttributeRoutingRegistration.cs" />
     <Compile Include="AttributeRoutingResolver.cs" />
+    <Compile Include="AttributeRoutingTable.cs" />
     <Compile Include="BeforeAttribute.cs" />
     <Compile Include="DefaultTypeProvider.cs" />
     <Compile Include="Exceptions\DuplicatedRoutingPathsException.cs" />

--- a/Nancy.AttributeRouting/Nancy.AttributeRouting.md
+++ b/Nancy.AttributeRouting/Nancy.AttributeRouting.md
@@ -2,6 +2,7 @@
 # Contents [#](#contents 'Go To Here')
 
 - [AttributeRoutingRegistration](#T-Nancy.AttributeRouting.AttributeRoutingRegistration 'Nancy.AttributeRouting.AttributeRoutingRegistration')
+  - [#ctor(typeProvider)](#M-Nancy.AttributeRouting.AttributeRoutingRegistration.#ctor-Nancy.AttributeRouting.ITypeProvider- 'Nancy.AttributeRouting.AttributeRoutingRegistration.#ctor(Nancy.AttributeRouting.ITypeProvider)')
   - [CollectionTypeRegistrations](#P-Nancy.AttributeRouting.AttributeRoutingRegistration.CollectionTypeRegistrations 'Nancy.AttributeRouting.AttributeRoutingRegistration.CollectionTypeRegistrations')
   - [InstanceRegistrations](#P-Nancy.AttributeRouting.AttributeRoutingRegistration.InstanceRegistrations 'Nancy.AttributeRouting.AttributeRoutingRegistration.InstanceRegistrations')
   - [TypeRegistrations](#P-Nancy.AttributeRouting.AttributeRoutingRegistration.TypeRegistrations 'Nancy.AttributeRouting.AttributeRoutingRegistration.TypeRegistrations')
@@ -9,11 +10,15 @@
   - [#ctor(container)](#M-Nancy.AttributeRouting.AttributeRoutingResolver.#ctor-Nancy.TinyIoc.TinyIoCContainer- 'Nancy.AttributeRouting.AttributeRoutingResolver.#ctor(Nancy.TinyIoc.TinyIoCContainer)')
 - [BeforeAttribute](#T-Nancy.AttributeRouting.BeforeAttribute 'Nancy.AttributeRouting.BeforeAttribute')
   - [Process(container,context)](#M-Nancy.AttributeRouting.BeforeAttribute.Process-Nancy.TinyIoc.TinyIoCContainer,Nancy.NancyContext- 'Nancy.AttributeRouting.BeforeAttribute.Process(Nancy.TinyIoc.TinyIoCContainer,Nancy.NancyContext)')
+- [DefaultTypeProvider](#T-Nancy.AttributeRouting.DefaultTypeProvider 'Nancy.AttributeRouting.DefaultTypeProvider')
+  - [Types](#P-Nancy.AttributeRouting.DefaultTypeProvider.Types 'Nancy.AttributeRouting.DefaultTypeProvider.Types')
 - [DeleteAttribute](#T-Nancy.AttributeRouting.DeleteAttribute 'Nancy.AttributeRouting.DeleteAttribute')
   - [#ctor(path)](#M-Nancy.AttributeRouting.DeleteAttribute.#ctor-System.String- 'Nancy.AttributeRouting.DeleteAttribute.#ctor(System.String)')
 - [DuplicatedRoutingPathsException](#T-Nancy.AttributeRouting.Exceptions.DuplicatedRoutingPathsException 'Nancy.AttributeRouting.Exceptions.DuplicatedRoutingPathsException')
 - [GetAttribute](#T-Nancy.AttributeRouting.GetAttribute 'Nancy.AttributeRouting.GetAttribute')
   - [#ctor(path)](#M-Nancy.AttributeRouting.GetAttribute.#ctor-System.String- 'Nancy.AttributeRouting.GetAttribute.#ctor(System.String)')
+- [ITypeProvider](#T-Nancy.AttributeRouting.ITypeProvider 'Nancy.AttributeRouting.ITypeProvider')
+  - [Types](#P-Nancy.AttributeRouting.ITypeProvider.Types 'Nancy.AttributeRouting.ITypeProvider.Types')
 - [IUrlBuilder](#T-Nancy.AttributeRouting.IUrlBuilder 'Nancy.AttributeRouting.IUrlBuilder')
   - [GetUrl\`\`1(expression)](#M-Nancy.AttributeRouting.IUrlBuilder.GetUrl``1-System.Linq.Expressions.Expression{System.Func{``0,System.Object}}- 'Nancy.AttributeRouting.IUrlBuilder.GetUrl``1(System.Linq.Expressions.Expression{System.Func{``0,System.Object}})')
   - [GetUrl\`\`1(expression,parameters)](#M-Nancy.AttributeRouting.IUrlBuilder.GetUrl``1-System.Linq.Expressions.Expression{System.Func{``0,System.Object}},System.Object- 'Nancy.AttributeRouting.IUrlBuilder.GetUrl``1(System.Linq.Expressions.Expression{System.Func{``0,System.Object}},System.Object)')
@@ -75,6 +80,19 @@ Nancy.AttributeRouting
 ##### Summary
 
 *Inherit from parent.*
+
+<a name='M-Nancy.AttributeRouting.AttributeRoutingRegistration.#ctor-Nancy.AttributeRouting.ITypeProvider-'></a>
+### #ctor(typeProvider) `constructor` [#](#M-Nancy.AttributeRouting.AttributeRoutingRegistration.#ctor-Nancy.AttributeRouting.ITypeProvider- 'Go To Here') [^](#contents 'Back To Contents')
+
+##### Summary
+
+Initializes a new instance of the [AttributeRoutingRegistration](#T-Nancy.AttributeRouting.AttributeRoutingRegistration 'Nancy.AttributeRouting.AttributeRoutingRegistration') class.
+
+##### Parameters
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| typeProvider | [Nancy.AttributeRouting.ITypeProvider](#T-Nancy.AttributeRouting.ITypeProvider 'Nancy.AttributeRouting.ITypeProvider') | The routing type provider. |
 
 <a name='P-Nancy.AttributeRouting.AttributeRoutingRegistration.CollectionTypeRegistrations'></a>
 ### CollectionTypeRegistrations `property` [#](#P-Nancy.AttributeRouting.AttributeRoutingRegistration.CollectionTypeRegistrations 'Go To Here') [^](#contents 'Back To Contents')
@@ -150,6 +168,24 @@ The response. If this is `null`, it will continue on view model execution, other
 | container | [Nancy.TinyIoc.TinyIoCContainer](#T-Nancy.TinyIoc.TinyIoCContainer 'Nancy.TinyIoc.TinyIoCContainer') | The Tiny IoC container. It provides [IUrlBuilder](#T-Nancy.AttributeRouting.IUrlBuilder 'Nancy.AttributeRouting.IUrlBuilder') and others to construct the response. |
 | context | [Nancy.NancyContext](#T-Nancy.NancyContext 'Nancy.NancyContext') | The Nancy context. It provides user information and others to determine whether continue view model execution. |
 
+<a name='T-Nancy.AttributeRouting.DefaultTypeProvider'></a>
+## DefaultTypeProvider [#](#T-Nancy.AttributeRouting.DefaultTypeProvider 'Go To Here') [^](#contents 'Back To Contents')
+
+##### Namespace
+
+Nancy.AttributeRouting
+
+##### Summary
+
+The default type provider for routing register.
+
+<a name='P-Nancy.AttributeRouting.DefaultTypeProvider.Types'></a>
+### Types `property` [#](#P-Nancy.AttributeRouting.DefaultTypeProvider.Types 'Go To Here') [^](#contents 'Back To Contents')
+
+##### Summary
+
+*Inherit from parent.*
+
 <a name='T-Nancy.AttributeRouting.DeleteAttribute'></a>
 ## DeleteAttribute [#](#T-Nancy.AttributeRouting.DeleteAttribute 'Go To Here') [^](#contents 'Back To Contents')
 
@@ -208,6 +244,24 @@ Initializes a new instance of the [GetAttribute](#T-Nancy.AttributeRouting.GetAt
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | path | [System.String](http://msdn.microsoft.com/query/dev14.query?appId=Dev14IDEF1&l=EN-US&k=k:System.String 'System.String') | The path to register into routing table. |
+
+<a name='T-Nancy.AttributeRouting.ITypeProvider'></a>
+## ITypeProvider [#](#T-Nancy.AttributeRouting.ITypeProvider 'Go To Here') [^](#contents 'Back To Contents')
+
+##### Namespace
+
+Nancy.AttributeRouting
+
+##### Summary
+
+Type provider to provide types for routing register.
+
+<a name='P-Nancy.AttributeRouting.ITypeProvider.Types'></a>
+### Types `property` [#](#P-Nancy.AttributeRouting.ITypeProvider.Types 'Go To Here') [^](#contents 'Back To Contents')
+
+##### Summary
+
+Gets the type list for routing register. Their methods decorated with [RouteAttribute](#T-Nancy.AttributeRouting.RouteAttribute 'Nancy.AttributeRouting.RouteAttribute') will be registed to routing table. By default, all types will be registed.
 
 <a name='T-Nancy.AttributeRouting.IUrlBuilder'></a>
 ## IUrlBuilder [#](#T-Nancy.AttributeRouting.IUrlBuilder 'Go To Here') [^](#contents 'Back To Contents')

--- a/Nancy.AttributeRouting/Nancy.AttributeRouting.xml
+++ b/Nancy.AttributeRouting/Nancy.AttributeRouting.xml
@@ -7,6 +7,11 @@
         <member name="T:Nancy.AttributeRouting.AttributeRoutingRegistration">
             <inheritdoc/>
         </member>
+        <member name="M:Nancy.AttributeRouting.AttributeRoutingRegistration.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Nancy.AttributeRouting.AttributeRoutingRegistration"/> class.
+            </summary>
+        </member>
         <member name="P:Nancy.AttributeRouting.AttributeRoutingRegistration.CollectionTypeRegistrations">
             <inheritdoc/>
         </member>

--- a/Nancy.AttributeRouting/Nancy.AttributeRouting.xml
+++ b/Nancy.AttributeRouting/Nancy.AttributeRouting.xml
@@ -7,10 +7,11 @@
         <member name="T:Nancy.AttributeRouting.AttributeRoutingRegistration">
             <inheritdoc/>
         </member>
-        <member name="M:Nancy.AttributeRouting.AttributeRoutingRegistration.#ctor">
+        <member name="M:Nancy.AttributeRouting.AttributeRoutingRegistration.#ctor(Nancy.AttributeRouting.ITypeProvider)">
             <summary>
             Initializes a new instance of the <see cref="T:Nancy.AttributeRouting.AttributeRoutingRegistration"/> class.
             </summary>
+            <param name="typeProvider">The routing type provider.</param>
         </member>
         <member name="P:Nancy.AttributeRouting.AttributeRoutingRegistration.CollectionTypeRegistrations">
             <inheritdoc/>
@@ -53,6 +54,27 @@
             The response. If this is <c>null</c>, it will continue on view model execution,
             otherwise it returns the this value directly.
             </returns>
+        </member>
+        <member name="T:Nancy.AttributeRouting.ITypeProvider">
+            <summary>
+            Type provider to provide types for routing register.
+            </summary>
+        </member>
+        <member name="P:Nancy.AttributeRouting.ITypeProvider.Types">
+            <summary>
+            Gets the type list for routing register.
+            Their methods decorated with <see cref="T:Nancy.AttributeRouting.RouteAttribute"/> will be registed to routing table.
+            By default, all types will be registed.
+            </summary>
+            <value>The type list.</value>
+        </member>
+        <member name="T:Nancy.AttributeRouting.DefaultTypeProvider">
+            <summary>
+            The default type provider for routing register.
+            </summary>
+        </member>
+        <member name="P:Nancy.AttributeRouting.DefaultTypeProvider.Types">
+            <inheritdoc/>
         </member>
         <member name="T:Nancy.AttributeRouting.Exceptions.DuplicatedRoutingPathsException">
             <summary>

--- a/Nancy.AttributeRouting/RouteAttribute.cs
+++ b/Nancy.AttributeRouting/RouteAttribute.cs
@@ -60,6 +60,10 @@
             }
         }
 
+        internal static IEnumerable<MethodInfo> GetMethods(Type type) =>
+            type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(m => m.GetCustomAttributes<RouteAttribute>().Any());
+
         private static IEnumerable<RoutingPath> GetRoutingPaths(MethodBase method)
         {
             string prefix = RoutePrefixAttribute.GetPrefix(method.DeclaringType);


### PR DESCRIPTION
Make non-static routing table and make it application wide.

- Introduce public `ITypeProvider` to inject types for routing
- Introduce internal `AttributeRoutingTable` to store all routing paths.
- Simple refine to avoid code redundant.